### PR TITLE
Enhancement/rofi on mod

### DIFF
--- a/.bashrc.template
+++ b/.bashrc.template
@@ -1,3 +1,2 @@
 alias config-rebuild="pushd . && cd <<CONFIG_REPO_PATH>> && ./build_config.sh && sudo cp generated/configuration.nix /etc/nixos/ && sudo nixos-rebuild switch && popd"
-XDG_CONFIG_HOME=<<CONFIG_REPO_PATH>>
 

--- a/.bashrc.template
+++ b/.bashrc.template
@@ -1,2 +1,3 @@
 alias config-rebuild="pushd . && cd <<CONFIG_REPO_PATH>> && ./build_config.sh && sudo cp generated/configuration.nix /etc/nixos/ && sudo nixos-rebuild switch && popd"
-export XMONAD_CONFIG_DIR=<<CONFIG_REPO_PATH>>
+XDG_CONFIG_HOME=<<CONFIG_REPO_PATH>>
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 generated/
+git/
+direnv/
+environment.d/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
 generated/
-git/
-direnv/
-environment.d/

--- a/configuration.nix.template
+++ b/configuration.nix.template
@@ -130,6 +130,10 @@
       pkgs.yarn
     ];
 
+    # Configure XDG config directory
+    xdg.enable = true;
+    xdg.configHome = <<CONFIG_REPO_PATH>>;
+
     # Enable direnv
     programs.direnv.enable = true;
     programs.direnv.nix-direnv.enable = true;

--- a/configuration.nix.template
+++ b/configuration.nix.template
@@ -142,6 +142,7 @@
     programs.bash = {
         enable = true;
         bashrcExtra = (builtins.readFile <<CONFIG_REPO_PATH>>/generated/.bashrc);
+        initExtra = ". $HOME/.nix-profile/etc/profile.d/hm-session-vars.sh";
     };
 
     # Configure Rofi

--- a/configuration.nix.template
+++ b/configuration.nix.template
@@ -118,6 +118,7 @@
       cargo
       nix-du
       zoom-us
+      rofi
     #  thunderbird
     ];
   };
@@ -144,12 +145,6 @@
         bashrcExtra = (builtins.readFile <<CONFIG_REPO_PATH>>/generated/.bashrc);
         initExtra = ". $HOME/.nix-profile/etc/profile.d/hm-session-vars.sh";
     };
-
-    # Configure Rofi
-    programs.rofi = {
-        enable = true;
-    };
-
 
     # Configure git
     programs.git = {

--- a/configuration.nix.template
+++ b/configuration.nix.template
@@ -51,13 +51,6 @@
   # Enable the X11 windowing system.
   services.xserver.enable = true;
 
-  # Enable the XMonad Window Manager
-  services.xserver.windowManager.xmonad = {
-    enable = true;
-    enableContribAndExtras = true;
-    config = builtins.readFile <<CONFIG_REPO_PATH>>/xmonad/xmonad.hs;
-  };
-
 
   # Configure keymap in X11
   services.xserver = {
@@ -93,6 +86,9 @@
 
   # Enable touchpad support (enabled default in most desktopManager).
   # services.xserver.libinput.enable = true;
+
+  # Enable xmonad
+  services.xserver.windowManager.xmonad.enable = true;
 
   # Enable docker
   virtualisation.docker.enable = true;
@@ -133,7 +129,12 @@
 
     # Configure XDG config directory
     xdg.enable = true;
-    xdg.configHome = <<CONFIG_REPO_PATH>>;
+    xdg.configFile = {
+      "rofi" = {
+        source = <<CONFIG_REPO_PATH>>/rofi/config.rasi;
+        target = "rofi/config.rasi";
+      };
+    };
 
     # Enable direnv
     programs.direnv.enable = true;
@@ -151,6 +152,13 @@
       enable = true;
       userName = "Kenneth Fang";
       userEmail = "fangkw42@gmail.com";
+    };
+
+    # Enable the XMonad Window Manager
+    xsession.windowManager.xmonad = {
+      enable = true;
+      enableContribAndExtras = true;
+      config = <<CONFIG_REPO_PATH>>/xmonad/xmonad.hs;
     };
   };
 

--- a/rofi/config.rasi
+++ b/rofi/config.rasi
@@ -1,0 +1,6 @@
+configuration {
+location: 0;
+xoffset: 0;
+yoffset: 0;
+kb-cancel: "Escape,Super_L";
+}

--- a/xmonad/xmonad.hs
+++ b/xmonad/xmonad.hs
@@ -4,9 +4,7 @@ import XMonad.Util.Ungrab
 
 main :: IO ()
 main = xmonad $ def
-    { modMask = mod4Mask -- Rebind Mod to Super Key
-    }
-  `additionalKeysP`
-    [ ("M-p", spawn "rofi -show run")
+  `additionalKeys`
+    [ ((noModMask, xK_Super_L), spawn "rofi -show run")
     ]
 


### PR DESCRIPTION
Enables toggling rofi using Super_L. Required configuring xmonad and rofi.

i had a super hard time trying to get xdg.configHome working in all cases, especially with xmonad's spawn command. Instead, I decided to just use xdg.configFile to copy over my dotfiles to `~/.config`. This worked with much less hassle.